### PR TITLE
Use v1 instead of v1alpha1 for meta.pkg.crossplane.io group

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1alpha1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Configuration
 metadata:
   name: configuration-scratch


### PR DESCRIPTION
### Description of your changes

v1alpha1 is deprecated in favor of v1 without any breaking changes.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Locally.